### PR TITLE
Fixed inaccurately high UTXO counts in utxosplitter.

### DIFF
--- a/utxosplitter.sh
+++ b/utxosplitter.sh
@@ -45,7 +45,7 @@ fi
     fi
     amount=$(calc $satoshis/100000000)
 
-    utxo_count=$(${cli} listunspent | jq -r '.[].amount' | grep ${amount} | wc -l)
+    utxo_count=$(${cli} listunspent | jq --arg amt "$amount" '[.[] | select(.amount==($amt|tonumber))] | length')
     echo "[${coin}] Current UTXO count is ${utxo_count}"
 
     utxo_required=$(calc ${target_utxo_count}-${utxo_count})


### PR DESCRIPTION
I was getting crazy results like
>[OOT] Current UTXO count is 1153

Changed UTXO check to more accurate version (credit to webworker01's stats script for method).